### PR TITLE
Add CMakeLists.txt and minor changes for compiling tesim under Linux

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.2)
+
+FIND_PACKAGE( Boost COMPONENTS system timer chrono log thread program_options REQUIRED )
+INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
+set (CMAKE_CXX_STANDARD 11)
+add_definitions(-DBOOST_LOG_DYN_LINK)
+ADD_EXECUTABLE( tesim ControlLoops.cpp PI.cpp TEChannel.cpp
+TEController.cpp TEErrorFreeChannel.cpp TEGEErrorChannel.cpp
+TEIIDErrorChannel.cpp TENames.cpp TEPlant.cpp teprob.cpp TETimeSync.cpp
+TETypes.cpp tesim_main.cpp)
+
+TARGET_LINK_LIBRARIES( tesim LINK_PUBLIC ${Boost_LIBRARIES} rt pthread)

--- a/c/TEController.cpp
+++ b/c/TEController.cpp
@@ -10,6 +10,7 @@
 
 #include "TEController.h"
 #include "teprob.h"
+#include <cstring>
 
 TEController* TEController::instance = 0;
 

--- a/c/TEPlant.cpp
+++ b/c/TEPlant.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>     // std::cout, std::ostream, std::ios
 #include <cstring>
+#include <cmath>
 
 #include "teprob.h"
 #include "TEPlant.h"

--- a/c/TETypes.cpp
+++ b/c/TETypes.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <iomanip>
 #include <string>
+#include <iostream>
 
 #include "TETypes.h"
 


### PR DESCRIPTION
This PR adds modifications to compile and run a basic `tesim` under Ubuntu Linux 14.04 (64bit), CMake 3.2.2 and Boost 1.54. Only few header includes needed to be added. It might work even with an older CMake (just lower the required version in the beginning of `CMakeLists.txt`).

I haven't tested whether this affects compile on Windows, as I don't have a Windows environment handy. Also I haven't done any comparisons whether it works properly, except that it produces `nochan_*.dat` files with simulation results when run `./tesim -s 10`.

Example compilation (make sure `libboost-dev` etc. are installed via `apt`) and run:
```
$ cd c/
$ cmake .
$ make
$ ./tesim -s 10
```